### PR TITLE
Replace structopt with clap

### DIFF
--- a/convert_kytea_model/Cargo.toml
+++ b/convert_kytea_model/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-structopt = "0.3"  # MIT or Apache-2.0
+clap = { version = "3.1", features = ["derive"] }  # MIT or Apache-2.0
 vaporetto = { path = "../vaporetto", features = ["kytea"] }  # MIT or Apache-2.0
 zstd = "0.9"  # MIT

--- a/convert_kytea_model/src/main.rs
+++ b/convert_kytea_model/src/main.rs
@@ -7,17 +7,17 @@ use clap::Parser;
 use vaporetto::{KyteaModel, Model};
 
 #[derive(Parser, Debug)]
-#[structopt(
+#[clap(
     name = "convert_kytea_model",
     about = "A program to convert KyTea model."
 )]
 struct Args {
     /// KyTea model file
-    #[structopt(long)]
+    #[clap(long)]
     model_in: PathBuf,
 
     /// Vespa model file
-    #[structopt(long)]
+    #[clap(long)]
     model_out: PathBuf,
 }
 

--- a/convert_kytea_model/src/main.rs
+++ b/convert_kytea_model/src/main.rs
@@ -3,15 +3,15 @@ use std::fs;
 use std::io::BufReader;
 use std::path::PathBuf;
 
-use structopt::StructOpt;
+use clap::Parser;
 use vaporetto::{KyteaModel, Model};
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 #[structopt(
     name = "convert_kytea_model",
     about = "A program to convert KyTea model."
 )]
-struct Opt {
+struct Args {
     /// KyTea model file
     #[structopt(long)]
     model_in: PathBuf,
@@ -22,15 +22,15 @@ struct Opt {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let opt = Opt::from_args();
+    let args = Args::parse();
 
     eprintln!("Loading model file...");
-    let mut f = BufReader::new(fs::File::open(opt.model_in).unwrap());
+    let mut f = BufReader::new(fs::File::open(args.model_in).unwrap());
     let model = KyteaModel::read(&mut f)?;
 
     eprintln!("Saving model file...");
     let model = Model::try_from(model)?;
-    let mut f = zstd::Encoder::new(fs::File::create(opt.model_out)?, 19)?;
+    let mut f = zstd::Encoder::new(fs::File::create(args.model_out)?, 19)?;
     model.write(&mut f)?;
     f.finish()?;
 

--- a/evaluate/Cargo.toml
+++ b/evaluate/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-structopt = "0.3"  # MIT or Apache-2.0
+clap = { version = "3.1", features = ["derive"] }  # MIT or Apache-2.0
 vaporetto = { path = "../vaporetto" }  # MIT or Apache-2.0
 vaporetto_rules = { path = "../vaporetto_rules" }  # MIT or Apache-2.0
 zstd = "0.9"  # MIT

--- a/manipulate_model/Cargo.toml
+++ b/manipulate_model/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+clap = { version = "3.1", features = ["derive"] }  # MIT or Apache-2.0
 csv = "1.1"  # Unlicense or MIT
 serde = { version = "1.0", features = ["derive"] }  # MIT or Apache-2.0
-structopt = "0.3"  # MIT or Apache-2.0
 vaporetto = { path = "../vaporetto" }  # MIT or Apache-2.0
 zstd = "0.9"  # MIT

--- a/manipulate_model/src/main.rs
+++ b/manipulate_model/src/main.rs
@@ -2,29 +2,29 @@ use std::fs;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
-use structopt::StructOpt;
+use clap::Parser;
 use vaporetto::{Model, WordWeightRecord};
 
-#[derive(StructOpt, Debug)]
-#[structopt(
+#[derive(Parser, Debug)]
+#[clap(
     name = "manipulate_model",
     about = "A program to manipulate tarined models."
 )]
-struct Opt {
+struct Args {
     /// Input path of the model file
-    #[structopt(long)]
+    #[clap(long)]
     model_in: PathBuf,
 
     /// Output path of the model file
-    #[structopt(long)]
+    #[clap(long)]
     model_out: Option<PathBuf>,
 
     /// Output a dictionary contained in the model.
-    #[structopt(long)]
+    #[clap(long)]
     dump_dict: Option<PathBuf>,
 
     /// Replace a dictionary if the argument is specified.
-    #[structopt(long)]
+    #[clap(long)]
     replace_dict: Option<PathBuf>,
 }
 
@@ -38,13 +38,13 @@ struct WordWeightRecordFlatten {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let opt = Opt::from_args();
+    let args = Args::parse();
 
     eprintln!("Loading model file...");
-    let mut f = zstd::Decoder::new(fs::File::open(opt.model_in)?)?;
+    let mut f = zstd::Decoder::new(fs::File::open(args.model_in)?)?;
     let mut model = Model::read(&mut f)?;
 
-    if let Some(path) = opt.dump_dict {
+    if let Some(path) = args.dump_dict {
         eprintln!("Saving dictionary file...");
         let file = fs::File::create(path)?;
         let mut wtr = csv::Writer::from_writer(file);
@@ -59,7 +59,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    if let Some(path) = opt.replace_dict {
+    if let Some(path) = args.replace_dict {
         eprintln!("Loading dictionary file...");
         let file = fs::File::open(path)?;
         let mut rdr = csv::Reader::from_reader(file);
@@ -77,7 +77,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         model.replace_dictionary(dict);
     }
 
-    if let Some(path) = opt.model_out {
+    if let Some(path) = args.model_out {
         eprintln!("Saving model file...");
         let mut f = zstd::Encoder::new(fs::File::create(path)?, 19)?;
         model.write(&mut f)?;

--- a/manipulate_model/src/main.rs
+++ b/manipulate_model/src/main.rs
@@ -1,8 +1,8 @@
 use std::fs;
 use std::path::PathBuf;
 
-use serde::{Deserialize, Serialize};
 use clap::Parser;
+use serde::{Deserialize, Serialize};
 use vaporetto::{Model, WordWeightRecord};
 
 #[derive(Parser, Debug)]

--- a/predict/Cargo.toml
+++ b/predict/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-structopt = "0.3"  # MIT or Apache-2.0
+clap = { version = "3.1.0", features = ["derive"] }  # MIT or Apache-2.0
 vaporetto = { path = "../vaporetto" }  # MIT or Apache-2.0
 vaporetto_rules = { path = "../vaporetto_rules" }  # MIT or Apache-2.0
 zstd = "0.9"  # MIT

--- a/train/Cargo.toml
+++ b/train/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-structopt = "0.3"  # MIT or Apache-2.0
+clap = { version = "3.1.0", features = ["derive"] }  # MIT or Apache-2.0
 vaporetto = { path = "../vaporetto", features = ["train"] }  # MIT or Apache-2.0
 vaporetto_rules = { path = "../vaporetto_rules" }  # MIT or Apache-2.0
 zstd = "0.9"  # MIT

--- a/train/src/main.rs
+++ b/train/src/main.rs
@@ -3,79 +3,79 @@ use std::fs::File;
 use std::io::{prelude::*, stderr, BufReader};
 use std::path::PathBuf;
 
-use structopt::{clap::ArgGroup, StructOpt};
+use clap::{ArgGroup, Parser};
 use vaporetto::{Sentence, SolverType, Trainer};
 use vaporetto_rules::{string_filters::KyteaFullwidthFilter, StringFilter};
 
-#[derive(StructOpt, Debug)]
-#[structopt(
+#[derive(Parser, Debug)]
+#[clap(
     name = "train",
     about = "A program to train models of Vespa.",
-    group = ArgGroup::with_name("dataset").required(true).multiple(true),
+    group = ArgGroup::new("dataset").required(true).multiple(true),
 )]
-struct Opt {
+struct Args {
     /// A tokenized training corpus
-    #[structopt(long, group = "dataset")]
+    #[clap(long, group = "dataset")]
     tok: Vec<PathBuf>,
 
     /// A partially annotated training corpus
-    #[structopt(long, group = "dataset")]
+    #[clap(long, group = "dataset")]
     part: Vec<PathBuf>,
 
     /// A word dictionary file
-    #[structopt(long)]
+    #[clap(long)]
     dict: Vec<PathBuf>,
 
     /// The file to write the trained model to
-    #[structopt(long)]
+    #[clap(long)]
     model: PathBuf,
 
     /// The character window to use for word segmentation
-    #[structopt(long, default_value = "3")]
+    #[clap(long, default_value = "3")]
     charw: usize,
 
     /// The character n-gram length to use for word segmentation
-    #[structopt(long, default_value = "3")]
+    #[clap(long, default_value = "3")]
     charn: usize,
 
     /// The character type window to use for word segmentation
-    #[structopt(long, default_value = "3")]
+    #[clap(long, default_value = "3")]
     typew: usize,
 
     /// The character type n-gram length to use for word segmentation
-    #[structopt(long, default_value = "3")]
+    #[clap(long, default_value = "3")]
     typen: usize,
 
     /// Dictionary words greater than this value will be grouped together
-    #[structopt(long, default_value = "4")]
+    #[clap(long, default_value = "4")]
     dictn: usize,
 
     /// The epsilon stopping criterion for classifier training
-    #[structopt(long, default_value = "0.01")]
+    #[clap(long, default_value = "0.01")]
     eps: f64,
 
     /// The cost hyperparameter for classifier training
-    #[structopt(long, default_value = "1.0")]
+    #[clap(long, default_value = "1.0")]
     cost: f64,
 
     /// The solver. {0, 1, 2, 3, 4, 5, 6, 7} (see LIBLINEAR documentation for more details)
-    #[structopt(long, default_value = "1")]
+    #[clap(long, default_value = "1")]
     solver: SolverType,
 
     /// Do not normalize training data.
-    #[structopt(long)]
+    #[clap(long)]
     no_norm: bool,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let opt = Opt::from_args();
+    let args = Args::parse();
 
     let fullwidth_filter = KyteaFullwidthFilter;
 
     eprintln!("Loading dataset...");
     let mut train_sents = vec![];
 
-    for path in opt.tok {
+    for path in args.tok {
         eprintln!("Loading {:?} ...", path);
         let f = File::open(path)?;
         let f = BufReader::new(f);
@@ -85,7 +85,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 stderr().flush()?;
             }
             let s = Sentence::from_tokenized(line?)?;
-            let s = if opt.no_norm {
+            let s = if args.no_norm {
                 s
             } else {
                 let new_line = fullwidth_filter.filter(s.to_raw_string());
@@ -98,7 +98,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         eprintln!("# of sentences: {}", train_sents.len());
     }
-    for path in opt.part {
+    for path in args.part {
         eprintln!("Loading {:?} ...", path);
         let f = File::open(path)?;
         let f = BufReader::new(f);
@@ -108,7 +108,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 stderr().flush()?;
             }
             let s = Sentence::from_partial_annotation(line?)?;
-            let s = if opt.no_norm {
+            let s = if args.no_norm {
                 s
             } else {
                 let new_line = fullwidth_filter.filter(s.to_raw_string());
@@ -123,7 +123,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let mut dictionary = BTreeSet::new();
-    for path in opt.dict {
+    for path in args.dict {
         eprintln!("Loading {:?} ...", path);
         let f = File::open(path)?;
         let f = BufReader::new(f);
@@ -133,7 +133,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 stderr().flush()?;
             }
             let line = line?;
-            let line = if opt.no_norm {
+            let line = if args.no_norm {
                 line
             } else {
                 fullwidth_filter.filter(&line)
@@ -146,7 +146,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     eprintln!("Extracting into features...");
     let mut trainer = Trainer::new(
-        opt.charn, opt.charw, opt.typen, opt.typew, dictionary, opt.dictn,
+        args.charn, args.charw, args.typen, args.typew, dictionary, args.dictn,
     )?;
     for (i, s) in train_sents.iter().enumerate() {
         if i % 10000 == 0 {
@@ -166,10 +166,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     eprintln!("Start training...");
-    let model = trainer.train(opt.eps, opt.cost, opt.solver)?;
+    let model = trainer.train(args.eps, args.cost, args.solver)?;
     eprintln!("Finish training.");
 
-    let mut f = zstd::Encoder::new(File::create(opt.model)?, 19)?;
+    let mut f = zstd::Encoder::new(File::create(args.model)?, 19)?;
     model.write(&mut f)?;
     f.finish()?;
 


### PR DESCRIPTION
This branch replaces structopt with clap.
structopt is a wrapper of clap, but its features are integrated into clap version 3.