### PR TITLE
Add feature of Charwise Daachorse

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,6 +78,12 @@ jobs:
           command: test
           args: --release -p vaporetto --no-default-features --features tag-prediction
 
+      - name: Run cargo test (vaporetto / features charwise-daachorse)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release -p vaporetto --no-default-features --features charwise-daachorse
+
   nightly:
     name: Nightly
     runs-on: ubuntu-latest
@@ -154,3 +160,9 @@ jobs:
         with:
           command: test
           args: --release -p vaporetto --no-default-features --features tag-prediction
+
+      - name: Run cargo test (vaporetto / features charwise-daachorse)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release -p vaporetto --no-default-features --features charwise-daachorse

--- a/vaporetto/Cargo.toml
+++ b/vaporetto/Cargo.toml
@@ -28,6 +28,7 @@ tag-prediction = []
 kytea = []
 train = ["liblinear"]
 portable-simd = ["fix-weight-length"]
+charwise-daachorse = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/vaporetto/README.md
+++ b/vaporetto/README.md
@@ -35,7 +35,7 @@ The following features are enabled by default:
 * `cache-type-score` - Enables caching type scores for faster processing. If disabled, type scores are calculated in a straightforward manner.
 * `fix-weight-length` - Uses fixed-size arrays for storing scores to facilitate optimization. If disabled, vectors are used instead.
 * `tag-prediction` - Enables tag prediction.
-* `charwise-daachorse` - Uses the [Charwise Daachorse](https://docs.rs/daachorse/latest/daachorse/charwise/index.html) instead of the standard version for faster tokenization. Note that it can make to load a model file slower.
+* `charwise-daachorse` - Uses the [Charwise Daachorse](https://docs.rs/daachorse/latest/daachorse/charwise/index.html) instead of the standard version for faster prediction, although it can make to load a model file slower.
 
 ## License
 

--- a/vaporetto/README.md
+++ b/vaporetto/README.md
@@ -35,6 +35,7 @@ The following features are enabled by default:
 * `cache-type-score` - Enables caching type scores for faster processing. If disabled, type scores are calculated in a straightforward manner.
 * `fix-weight-length` - Uses fixed-size arrays for storing scores to facilitate optimization. If disabled, vectors are used instead.
 * `tag-prediction` - Enables tag prediction.
+* `charwise-daachorse` - Uses the [Charwise Daachorse](https://docs.rs/daachorse/latest/daachorse/charwise/index.html) instead of the standard version for faster tokenization. Note that it can make to load a model file slower.
 
 ## License
 

--- a/vaporetto/README.md
+++ b/vaporetto/README.md
@@ -29,13 +29,13 @@ The following features are disabled by default:
 * `train` - Enables the trainer.
 * `portable-simd` - Uses the [portable SIMD API](https://github.com/rust-lang/portable-simd) instead
   of our SIMD-conscious data layout. (Nightly Rust is required.)
+* `charwise-daachorse` - Uses the [Charwise Daachorse](https://docs.rs/daachorse/latest/daachorse/charwise/index.html) instead of the standard version for faster prediction, although it can make to load a model file slower.
 
 The following features are enabled by default:
 
 * `cache-type-score` - Enables caching type scores for faster processing. If disabled, type scores are calculated in a straightforward manner.
 * `fix-weight-length` - Uses fixed-size arrays for storing scores to facilitate optimization. If disabled, vectors are used instead.
 * `tag-prediction` - Enables tag prediction.
-* `charwise-daachorse` - Uses the [Charwise Daachorse](https://docs.rs/daachorse/latest/daachorse/charwise/index.html) instead of the standard version for faster prediction, although it can make to load a model file slower.
 
 ## License
 


### PR DESCRIPTION
This PR added a feature to enable `Charwise Daachorse` for faster prediction.

I conducted an easy experiment with KyTea model. With this feature, prediction was faster, but loading a model was slower.

- Without charwise daachorse
```
$ cargo run --release -p predict -- --model jp-0.4.7-5-tokenize.model.zst < wagahaiwa_nekodearu.txt > /dev/null 
Loading model file...
Elapsed time for Predictor::new: 7.472032368 [sec]
Start tokenization
Elapsed: 0.090090412 [sec]
```
- With charwise daachorse
```
$ cargo run --release -p predict -- --model jp-0.4.7-5-tokenize.model.zst < wagahaiwa_nekodearu.txt > /dev/null 
Loading model file...
Elapsed time for Predictor::new: 15.159441012 [sec]
Start tokenization
Elapsed: 0.083684763 [sec]
```