### PR TITLE
Fix errors on clippy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -117,7 +117,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings -W clippy::nursery -W clippy::cast_lossless -W clippy::cast_possible_truncation -W clippy::cast_possible_wrap -A clippy::empty_line_after_outer_attr
+          args: -- -D warnings -W clippy::nursery -W clippy::cast_lossless -W clippy::cast_possible_truncation -W clippy::cast_possible_wrap -A clippy::empty_line_after_outer_attr -A clippy::significant-drop-in-scrutinee
 
       - name: Run cargo test (workspace)
         uses: actions-rs/cargo@v1

--- a/vaporetto/src/predictor.rs
+++ b/vaporetto/src/predictor.rs
@@ -54,12 +54,12 @@ impl Decode for WeightVector {
 impl Encode for WeightVector {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
         match self {
-            WeightVector::Variable(w) => {
+            Self::Variable(w) => {
                 Encode::encode(&w, encoder)?;
             }
 
             #[cfg(feature = "fix-weight-length")]
-            WeightVector::Fixed(w) => {
+            Self::Fixed(w) => {
                 #[cfg(feature = "portable-simd")]
                 let w = w.as_array();
 
@@ -74,14 +74,14 @@ impl Encode for WeightVector {
 impl WeightVector {
     pub fn add_scores(&self, ys: &mut [i32]) {
         match self {
-            WeightVector::Variable(w) => {
+            Self::Variable(w) => {
                 for (y, x) in ys.iter_mut().zip(w) {
                     *y += *x;
                 }
             }
 
             #[cfg(feature = "fix-weight-length")]
-            WeightVector::Fixed(w) => {
+            Self::Fixed(w) => {
                 #[cfg(not(feature = "portable-simd"))]
                 for (y, x) in ys[..WEIGHT_FIXED_LEN].iter_mut().zip(w) {
                     *y += *x
@@ -100,10 +100,10 @@ impl WeightVector {
 
     pub fn len(&self) -> usize {
         match self {
-            WeightVector::Variable(w) => w.len(),
+            Self::Variable(w) => w.len(),
 
             #[cfg(feature = "fix-weight-length")]
-            WeightVector::Fixed(_) => WEIGHT_FIXED_LEN,
+            Self::Fixed(_) => WEIGHT_FIXED_LEN,
         }
     }
 }


### PR DESCRIPTION
Clippy in Nightly Rust reports `use_self`. This branch fixes that error.

I disabled `clippy::significant-drop-in-scrutinee` in Nightly because I think this warning is false positive.