### PR TITLE
Disable charwise-pma in wasm

### DIFF
--- a/examples/wasm/Cargo.toml
+++ b/examples/wasm/Cargo.toml
@@ -8,7 +8,7 @@ bincode = "2.0.0-rc.1"  # MIT
 once_cell = "1.12.0"  # MIT or Apache-2.0
 ruzstd = "0.2.4"  # MIT
 serde = "1"  # MIT or Apache-2.0
-vaporetto = { path = "../../vaporetto" }  # MIT or Apache-2.0
+vaporetto = { path = "../../vaporetto", default-features = false, features = ["std", "cache-type-score", "fix-weight-length", "tag-prediction"] }  # MIT or Apache-2.0
 vaporetto_rules = { path = "../../vaporetto_rules" }  # MIT or Apache-2.0
 wasm-bindgen = "0.2.81"  # MIT or Apache-2.0
 web-sys = { version = "0.3", features = ["Event", "EventTarget", "InputEvent"] }  # MIT or Apache-2.0


### PR DESCRIPTION
On my PC (MacBookPro M1), the older version with `charwise-pma` takes four flashes of text `loading...` to load the model in Wasm Demo. Disabling the feature improves the number of flashes to three times.