### PR TITLE
Enable sparse-registry on nightly Cargo

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
 
 name: build
 
+env:
+  CARGO_UNSTABLE_SPARSE_REGISTRY: true
+
 jobs:
   msrv:
     name: MSRV


### PR DESCRIPTION
This branch enables [sparse-registry](https://blog.rust-lang.org/2022/06/22/sparse-registry-testing.html) on Nightly Cargo.