### PR TITLE
Remove unnecessary attribute "resolver = 2"

### DIFF
--- a/vaporetto_rules/Cargo.toml
+++ b/vaporetto_rules/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/daac-tools/vaporetto"
 readme = "README.md"
 keywords = ["japanese", "analyzer", "tokenizer", "morphological"]
 categories = ["text-processing", "no-std"]
-resolver = "2"
 
 [dependencies]
 hashbrown = "0.12.1"  # MIT or Apache-2.0


### PR DESCRIPTION
The current configuration causes the message `warning: resolver for the non root package will be ignored ...`.
This branch fixes this warning.