### PR TITLE
Workaround for clippy bug

### DIFF
--- a/evaluate/src/main.rs
+++ b/evaluate/src/main.rs
@@ -99,6 +99,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     eprintln!("Start tokenization");
 
     let mut results = vec![];
+    #[allow(clippy::significant_drop_in_scrutinee)]
     for line in stdin().lock().lines() {
         let line = line?;
         if line.is_empty() {

--- a/evaluate/src/main.rs
+++ b/evaluate/src/main.rs
@@ -99,6 +99,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     eprintln!("Start tokenization");
 
     let mut results = vec![];
+    // FIXME: The following clippy annotation is a workaround for the following bug:
+    // https://github.com/rust-lang/rust-clippy/issues/9135
     #[allow(clippy::significant_drop_in_scrutinee)]
     for line in stdin().lock().lines() {
         let line = line?;

--- a/predict/src/main.rs
+++ b/predict/src/main.rs
@@ -104,6 +104,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut buf = String::new();
     let mut s = Sentence::default();
     if args.no_norm {
+        // FIXME: The following clippy annotation is a workaround for the following bug:
+        // https://github.com/rust-lang/rust-clippy/issues/9135
         #[allow(clippy::significant_drop_in_scrutinee)]
         for line in io::stdin().lock().lines() {
             let line = line?;
@@ -124,6 +126,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     } else {
         let mut s_orig = Sentence::default();
+        // FIXME: The following clippy annotation is a workaround for the following bug:
+        // https://github.com/rust-lang/rust-clippy/issues/9135
         #[allow(clippy::significant_drop_in_scrutinee)]
         for line in io::stdin().lock().lines() {
             let line = line?;

--- a/predict/src/main.rs
+++ b/predict/src/main.rs
@@ -104,6 +104,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut buf = String::new();
     let mut s = Sentence::default();
     if args.no_norm {
+        #[allow(clippy::significant_drop_in_scrutinee)]
         for line in io::stdin().lock().lines() {
             let line = line?;
             if s.update_raw(line).is_ok() {
@@ -123,6 +124,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     } else {
         let mut s_orig = Sentence::default();
+        #[allow(clippy::significant_drop_in_scrutinee)]
         for line in io::stdin().lock().lines() {
             let line = line?;
             let line_preproc = pre_filter.filter(&line);


### PR DESCRIPTION
The latest version of Clippy reports false-positive warnings due to the following bug.
https://github.com/rust-lang/rust-clippy/issues/9135

This PR temporarily disables this lint.