### PR TITLE
Deploy demo page without creating branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,31 +7,57 @@ on:
 name: deploy
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+
     - name: Download model
       working-directory: ./examples/wasm
       run: |
         wget 'https://github.com/daac-tools/vaporetto/releases/download/v0.5.0/bccwj-suw+unidic+tag-huge.tar.xz'
         tar xf ./bccwj-suw+unidic+tag-huge.tar.xz
         mv ./bccwj-suw+unidic+tag-huge/bccwj-suw+unidic+tag-huge.model.zst ./src/
+
     - name: Install environment
       run: |
         rustup target add wasm32-unknown-unknown
         cargo install trunk
+
     - name: Build
       working-directory: ./examples/wasm
       run: trunk build --release --public-url vaporetto
-    - name: Publish
-      run: cp -r ./examples/wasm/dist/ ./public/
-    - uses: peaceiris/actions-gh-pages@v3
+
+    - name: Archive artifact
+      shell: bash
+      if: runner.os == 'Linux'
+      run: |
+        tar \
+          --dereference --hard-dereference \
+          --directory ./examples/wasm/dist \
+          -cvf ${{ runner.temp }}/artifact.tar \
+          .
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@main
       if: ${{ github.ref == 'refs/heads/main' }}
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./public
-        force_orphan: true
+        name: github-pages
+        path: ${{ runner.temp }}/artifact.tar
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
Currently, the workflow creates a branch named `gh-pages` to store a built demo page.
Instead, this branch uses *actions/deploy-pages* to deploy the demo page without creating branch.