### PR TITLE
Setup CI for Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,8 +12,8 @@ permissions:
   id-token: write
 
 jobs:
-  build:
-    name: Check wasm
+  publish:
+    name: Publish to Cloudflare Pages
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -32,33 +32,29 @@ jobs:
 
     - name: Build
       working-directory: ./examples/wasm
-      run: trunk build --release --public-url vaporetto
+      run: trunk build --release
 
-    - name: Archive artifact
-      shell: bash
-      if: runner.os == 'Linux'
-      run: |
-        tar \
-          --dereference --hard-dereference \
-          --directory ./examples/wasm/dist \
-          -cvf ${{ runner.temp }}/artifact.tar \
-          .
-
-    - name: Upload artifact
-      uses: actions/upload-artifact@main
-      if: ${{ github.ref == 'refs/heads/main' }}
+    - name: Publish to Cloudflare Pages
+      id: cloudflare_pages_deploy
+      uses: cloudflare/pages-action@v1
       with:
-        name: github-pages
-        path: ${{ runner.temp }}/artifact.tar
+        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        projectName: vaporetto-demo
+        directory: ./examples/wasm/dist
+        gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' }}
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v1
+    - name: Add publish URL as commit status
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const sha = context.payload.pull_request?.head.sha ?? context.sha;
+          await github.rest.repos.createCommitStatus({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            context: 'Cloudflare Pages',
+            description: 'Cloudflare Pages deployment',
+            state: 'success',
+            sha,
+            target_url: "${{ steps.cloudflare_pages_deploy.outputs.url }}",
+          });

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,15 +6,15 @@ on:
 
 name: deploy
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 jobs:
   publish:
     name: Publish to Cloudflare Pages
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+      statuses: write
+
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
This PR changes the server of the demo from GitHub Pages to Cloudflare Pages because Cloudflare Pages supports the preview feature.
![Screenshot from 2023-02-04 15-18-02](https://user-images.githubusercontent.com/2175479/216752416-f5c384ba-657f-4aff-8c09-00206c7ed21f.png)
