### PR TITLE
Update bincode to 2.0.0-rc.3

### DIFF
--- a/vaporetto/Cargo.toml
+++ b/vaporetto/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["japanese", "analyzer", "tokenizer", "morphological"]
 categories = ["text-processing", "no-std"]
 
 [dependencies]
-bincode = { version = "2.0.0-rc.2", default-features = false, features = ["alloc", "derive"] }  # MIT
+bincode = { version = "2.0.0-rc.3", default-features = false, features = ["alloc", "derive"] }  # MIT
 daachorse = "1.0.0"  # MIT or Apache-2.0
 hashbrown = "0.13.2"  # MIT or Apache-2.0
 

--- a/vaporetto/src/ngram_model.rs
+++ b/vaporetto/src/ngram_model.rs
@@ -9,7 +9,7 @@ pub struct NgramData<T> {
 }
 
 #[derive(Default, Debug, Decode, Encode)]
-pub struct NgramModel<T>(pub Vec<NgramData<T>>);
+pub struct NgramModel<T: 'static>(pub Vec<NgramData<T>>);
 
 #[derive(Clone, Debug, Decode, Encode)]
 pub struct TagWeight {
@@ -24,4 +24,4 @@ pub struct TagNgramData<T> {
 }
 
 #[derive(Default, Debug, Decode, Encode)]
-pub struct TagNgramModel<T>(pub Vec<TagNgramData<T>>);
+pub struct TagNgramModel<T: 'static>(pub Vec<TagNgramData<T>>);

--- a/vaporetto/src/predictor.rs
+++ b/vaporetto/src/predictor.rs
@@ -44,6 +44,12 @@ pub enum WeightVector {
     Fixed(I32Simd),
 }
 
+impl Default for WeightVector {
+    fn default() -> Self {
+        Self::Variable(vec![])
+    }
+}
+
 impl Decode for WeightVector {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
         let weight: Vec<i32> = Decode::decode(decoder)?;

--- a/vaporetto/src/utils.rs
+++ b/vaporetto/src/utils.rs
@@ -63,8 +63,8 @@ where
         let mut result = HashMap::with_hasher(S::default());
         let size: u64 = Decode::decode(decoder)?;
         for _ in 0..size {
-            let k: K = Decode::decode(decoder)?;
-            let v: V = Decode::decode(decoder)?;
+            let k = Decode::decode(decoder)?;
+            let v = Decode::decode(decoder)?;
             result.insert(k, v);
         }
         Ok(Self(result))

--- a/vaporetto/src/utils.rs
+++ b/vaporetto/src/utils.rs
@@ -2,7 +2,6 @@ use core::hash::{BuildHasher, Hash, Hasher};
 use core::ops::{Deref, DerefMut};
 
 use alloc::vec::Vec;
-use hashbrown::hash_map::DefaultHashBuilder;
 
 #[cfg(feature = "kytea")]
 use std::io::{self, Read};
@@ -13,7 +12,7 @@ use bincode::{
     error::{DecodeError, EncodeError},
     Decode, Encode,
 };
-use hashbrown::HashMap;
+use hashbrown::{hash_map::DefaultHashBuilder, HashMap};
 
 #[cfg(feature = "fix-weight-length")]
 #[inline(always)]


### PR DESCRIPTION
This branch updates bincode to 2.0.0-rc.3.

The previous implementation casts `hashbrown::HashMap` to `Vec` before serialization. In this branch, Vaporetto iterates over `hashbrown::HashMap` and serializes directly to avoid type casting.
This not only reduces unnecessary casting costs but also solves errors associated with updates.