### PR TITLE
Add const to some functions and allow missing_const_for_fn

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run cargo clippy
         continue-on-error: ${{ matrix.rust == 'nightly' }}
-        run: cargo clippy -- -D warnings -W clippy::nursery -W clippy::cast_lossless -W clippy::cast_possible_truncation -W clippy::cast_possible_wrap -A clippy::empty_line_after_outer_attr
+        run: cargo clippy -- -D warnings -W clippy::nursery -W clippy::cast_lossless -W clippy::cast_possible_truncation -W clippy::cast_possible_wrap -A clippy::empty_line_after_outer_attr -A clippy::missing_const_for_fn
 
       - name: Run cargo test (workspace)
         run: cargo test --release --workspace

--- a/vaporetto/src/predictor.rs
+++ b/vaporetto/src/predictor.rs
@@ -509,7 +509,7 @@ impl Predictor {
 
     /// Stores tag scores if the given `flag` is `true`.
     #[cfg(feature = "tag-prediction")]
-    pub fn store_tag_scores(&mut self, flag: bool) {
+    pub const fn store_tag_scores(&mut self, flag: bool) {
         self.tag_scores = flag;
     }
 

--- a/vaporetto/src/sentence.rs
+++ b/vaporetto/src/sentence.rs
@@ -1168,7 +1168,7 @@ assert_eq!(
     }
 
     #[inline]
-    pub(crate) fn set_predictor(&mut self, predictor: &'b Predictor) {
+    pub(crate) const fn set_predictor(&mut self, predictor: &'b Predictor) {
         self.predictor.replace(predictor);
     }
 

--- a/vaporetto/src/utils.rs
+++ b/vaporetto/src/utils.rs
@@ -92,7 +92,7 @@ pub struct SplitMix64 {
 }
 
 impl SplitMix64 {
-    fn add(&mut self, i: u64) {
+    const fn add(&mut self, i: u64) {
         self.x ^= i;
         self.x = self.x.wrapping_add(0x9e3779b97f4a7c15);
         self.x = (self.x ^ (self.x >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);

--- a/vaporetto_tantivy/src/lib.rs
+++ b/vaporetto_tantivy/src/lib.rs
@@ -92,8 +92,8 @@ impl VaporettoTokenizer {
     ///
     /// * `model` - A model data of Vaporetto.
     /// * `wsconst` - Character types that the tokenizer does not segment.
-    ///               D: Digit, R: Roman, H: Hiragana, T: Katakana, K: Kanji, O: Other,
-    ///               G: Grapheme cluster.
+    ///   D: Digit, R: Roman, H: Hiragana, T: Katakana, K: Kanji, O: Other,
+    ///   G: Grapheme cluster.
     ///
     /// # Errors
     ///
@@ -116,8 +116,8 @@ impl VaporettoTokenizer {
     ///
     /// * `data` - Serialized data of Vaporetto.
     /// * `wsconst` - Character types that the tokenizer does not segment.
-    ///               D: Digit, R: Roman, H: Hiragana, T: Katakana, K: Kanji, O: Other,
-    ///               G: Grapheme cluster.
+    ///   D: Digit, R: Roman, H: Hiragana, T: Katakana, K: Kanji, O: Other,
+    ///   G: Grapheme cluster.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
clippy::missing_const_for_fn detects many false positives in Rust 1.86